### PR TITLE
ci: update GitHub Actions to clear Node 20 deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -34,7 +34,7 @@ jobs:
         run: npm run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./dist
 
@@ -47,4 +47,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## 概要

GitHub Pages デプロイ (`deploy.yml`) の実行で **Node.js 20 非推奨警告**が出ていたため、原因となる Actions のバージョンを更新します。警告は、pin していた Action が内部で Node 20 ランタイムを同梱しており、GitHub がランナーから Node 20 を廃止予定であることに起因します。

参照: マージ #58 のデプロイ実行 https://github.com/F88/PROMIDAS-demo/actions/runs/28856586187

## 変更内容

| Action | 変更 | 効果 |
|---|---|---|
| `actions/upload-pages-artifact` | v4 -> v5 | 内部の upload-artifact を v7 化 (Node 20 警告解消) |
| `actions/deploy-pages` | v4 -> v5 | Node.js 24.x 化 (Node 20 警告解消) |
| `actions/checkout` | v6 -> v7 | ci.yml / deploy.yml 両方。鮮度維持 |

- `setup-node` は `@v6` が既に最新メジャー (v6.4.0) のため据え置き
- `checkout` v7 は fork PR の `pull_request_target`/`workflow_run` チェックアウト制限を強化するのみで、当ワークフローは `pull_request` 使用のため影響なし

## 検証

- ワークフローの `uses:` バージョン変更のみ (ロジック変更なし)
- マージ後、`deploy.yml` が自動実行され Node 20 警告が消えることを確認予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)