### PR TITLE
chore(deps): update promidas-utils to 3.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@mui/icons-material": "^9.2.0",
         "@mui/material": "^9.2.0",
         "promidas": "^3.0.1",
-        "promidas-utils": "~3.0.0",
+        "promidas-utils": "^3.2.1",
         "protopedia-api-v2-client": "^3.0.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7"
@@ -8821,9 +8821,9 @@
       }
     },
     "node_modules/promidas-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/promidas-utils/-/promidas-utils-3.0.0.tgz",
-      "integrity": "sha512-02MK1X445qakDLCHA+N4dZN3CTv/HyZGuG4ErLjrcDZmhMTYDbj6l/Pq1tmrVCZxV+48HhWEkyyI8bRnqoelwg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/promidas-utils/-/promidas-utils-3.2.1.tgz",
+      "integrity": "sha512-jN6ZRC+OYBlT4uKGNDQNu0Y3xsH/Ln9lHElIP2RcF9XJWn0EJ2JQ7OLzaIpj4fPatfKZQH8nVNtZpsae5x0mHw==",
       "license": "MIT",
       "engines": {
         "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@mui/icons-material": "^9.2.0",
     "@mui/material": "^9.2.0",
     "promidas": "^3.0.1",
-    "promidas-utils": "~3.0.0",
+    "promidas-utils": "^3.2.1",
     "protopedia-api-v2-client": "^3.0.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"


### PR DESCRIPTION
## 概要

`promidas-utils` を 3.2.1 へ更新します。3.2.1 は [F88/promidas-utils#48](https://github.com/F88/promidas-utils/issues/48) で報告したブラウザビルド破壊のリグレッションを修正しています。

## 背景

PR #58 の依存更新時、`promidas-utils` 3.1.0+ で `vite build` が失敗する問題を検出し、`~3.0.0` に固定して見送っていました。原因は `/repository` バレルが Node 専用の `snapshot-file-io.js` (`node:crypto` の `randomUUID` 等) を re-export していたことです。

## 3.2.1 での修正

- `/repository` バレルから `snapshot-file-io` の re-export を削除 (`toLocalizedMessage` 等は従来どおり提供)
- Node 専用 file-IO を新設の `./file-io` サブパスへ分離
- `exports` マップに `./file-io` を追加

## 変更内容

- `promidas-utils` `~3.0.0` -> `^3.2.1` (ブラウザ安全になったため caret 規約に復帰)

## 検証

- `npm run build` ✓ (以前 `randomUUID` 解決で失敗していたビルドが成功)
- `npm test` (166 passed) ✓
- `npm run lint` ✓
- `npm run format:check` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)