### PR TITLE
feat: show prototype authors via promidas-utils parseUsername

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [CalVer](https://calver.org/).
 
+## [Unreleased]
+
+### PROMIDAS versions
+
+- Upgraded `promidas` to `v3.0.1`.
+- Upgraded `promidas-utils` to `v3.2.1`.
+
+### Changed
+
+- Adopted `parseUsername` from `promidas-utils` (added in v3.2.0) to decode each
+  prototype author into `displayName (profileId)` on the prototype card.
+
 ## [2026.01.28] - 2026-01-28
 
 ### Changed
@@ -15,10 +27,13 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ## [3.0.0] - 2026-01-28
 
-### Changed
+### PROMIDAS versions
 
 - Upgraded `promidas` to `v3.0.0`.
 - Upgraded `promidas-utils` to `v3.0.0`.
+
+### Changed
+
 - Migrated ESLint configuration from `eslint.config.js` to `eslint.config.mjs`
 - Enhanced import ordering rules:
     - Grouped parent and sibling imports together to reduce newline conflicts
@@ -34,10 +49,13 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ## [2.0.0] - 2026-01-16
 
-### Changed
+### PROMIDAS versions
 
 - Migrated `@f88/promidas` from GitHub packages to npm registry as `promidas` (v2.0.0).
 - Migrated `@f88/promidas-utils` from GitHub packages to npm registry as `promidas-utils` (v2.0.0).
+
+### Changed
+
 - Updated all imports to use new package names.
 - Enhanced build configuration to split promidas packages into separate chunks for better caching.
 
@@ -47,14 +65,17 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ## [1.1.0] - 2026-01-13
 
+### PROMIDAS versions
+
+- Upgraded `@f88/promidas` to `v1.1.0`.
+- Upgraded `@f88/promidas-utils` to `v1.0.0`.
+
 ### Added
 
 - Support for PROMIDAS-1.1.0 and PROMIDAS-Utils-1.0.0.
 
 ### Changed
 
-- Upgraded `@f88/promidas` to `v1.1.0`.
-- Upgraded `@f88/promidas-utils` to `v1.0.0`.
 - Updated Node.js engine requirement to `>=22`.
 
 ## [1.0.0] - 2025-12-24

--- a/src/components/common/prototype-card.stories.tsx
+++ b/src/components/common/prototype-card.stories.tsx
@@ -23,7 +23,7 @@ function createMockPrototype(
     viewCount: 1250,
     goodCount: 42,
     commentCount: 8,
-    users: ['user1', 'user2'],
+    users: ['Alice@alice', 'Bob@bob'],
     teamNm: 'Tech Innovators',
     tags: ['IoT', 'Arduino', 'Cloud'],
     materials: ['ESP32', 'Temperature Sensor'],
@@ -160,6 +160,29 @@ export const JapaneseContent: Story = {
       summary:
         'Arduinoとクラウド連携を使用したリアルタイムデータ追跡のためのスマート温度監視システムです。',
       teamNm: '技術イノベーターズ',
+    }),
+  },
+};
+
+/**
+ * User name variations, decoded by parseUsername (promidas-utils) and shown
+ * as `displayName (profileId)`. Each element is a ProtoPedia
+ * `displayName@profileId` string covering a pattern seen in real data:
+ * normal, empty display name, display name containing `@`, and a malformed
+ * value with no `@` separator.
+ */
+export const UserNameVariations: Story = {
+  args: {
+    prototype: createMockPrototype({
+      prototypeNm: 'Username Parsing Showcase',
+      summary:
+        'Demonstrates how parseUsername decomposes each users[] element into a display name and a profile id.',
+      users: [
+        'Alice@alice', // normal -> "Alice (alice)"
+        '@bob', // empty display name -> "@bob"
+        'Carol@Example@carol', // display name contains '@' -> "Carol@Example (carol)"
+        'legacy-handle', // no '@' separator -> "legacy-handle"
+      ],
     }),
   },
 };

--- a/src/components/common/prototype-card.tsx
+++ b/src/components/common/prototype-card.tsx
@@ -99,9 +99,7 @@ export function PrototypeCard({ prototype }: PrototypeCardProps) {
               >
                 {prototype.users.map((user, index) => {
                   const parsedUsername = parseUsername(user);
-                  const profileUrl = buildUserLink(
-                    parsedUsername.profileId || parsedUsername.displayName,
-                  );
+                  const profileUrl = buildUserLink(parsedUsername.profileId ?? '');
                   return profileUrl ? (
                     <Chip
                       key={index}

--- a/src/components/common/prototype-card.tsx
+++ b/src/components/common/prototype-card.tsx
@@ -1,12 +1,12 @@
 import CategoryIcon from '@mui/icons-material/Category';
 import EventIcon from '@mui/icons-material/Event';
+import GroupsIcon from '@mui/icons-material/Groups';
 import LocalOfferIcon from '@mui/icons-material/LocalOffer';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import PeopleIcon from '@mui/icons-material/People';
 import {
   Button,
   Card,
-  CardActionArea,
   CardActions,
   CardContent,
   CardHeader,
@@ -14,11 +14,27 @@ import {
   Stack,
   Typography,
 } from '@mui/material';
+import { parseUsername, type ParsedUsername } from 'promidas-utils/utils';
+
+import { buildPrototypeLink, buildUserLink } from '../../utils/link';
 
 import type { NormalizedPrototype } from 'promidas/types';
 
 interface PrototypeCardProps {
   prototype: NormalizedPrototype;
+}
+
+/**
+ * Format a ProtoPedia username element (`displayName@profileId`) for display
+ * as `displayName (profileId)`, using parseUsername from promidas-utils.
+ */
+function formatUsername(parsedUsername: ParsedUsername): string {
+  const { displayName, profileId } = parsedUsername;
+  if (displayName && profileId) {
+    return `${displayName} (${profileId})`;
+  }
+  // Empty display name (~20% of authors) -> show the handle; no `@` -> as-is.
+  return displayName || (profileId ? `@${profileId}` : '');
 }
 
 export function PrototypeCard({ prototype }: PrototypeCardProps) {
@@ -30,142 +46,166 @@ export function PrototypeCard({ prototype }: PrototypeCardProps) {
         boxShadow: 2,
       }}
     >
-      <CardActionArea>
-        <CardHeader
-          title={prototype.prototypeNm}
-          subheader={`ID: ${prototype.id}`}
-        />
+      <CardHeader
+        title={prototype.prototypeNm}
+        subheader={`ID: ${prototype.id}`}
+      />
 
-        <CardContent>
-          {prototype.summary && (
-            <Typography
-              //
-              variant="body1"
+      <CardContent>
+        {prototype.summary && (
+          <Typography
+            //
+            variant="body1"
+            sx={{
+              color: 'text.secondary',
+              mb: 2,
+            }}
+          >
+            {prototype.summary}
+          </Typography>
+        )}
+
+        <Stack spacing={1.5} sx={{ mt: 2 }}>
+          {/* Teamm */}
+          {prototype.teamNm && (
+            <Stack
+              direction="row"
+              spacing={0.5}
               sx={{
-                color: 'text.secondary',
-                mb: 2,
+                alignItems: 'center',
               }}
             >
-              {prototype.summary}
-            </Typography>
+              <GroupsIcon fontSize="small" color="action" sx={{ mr: 0.5 }} />
+              <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                {prototype.teamNm}
+              </Typography>
+            </Stack>
           )}
 
-          <Stack spacing={1.5} sx={{ mt: 2 }}>
-            {prototype.users && prototype.users.length > 0 && (
+          {/* Users  */}
+          {prototype.users && prototype.users.length > 0 && (
+            <Stack
+              direction="row"
+              spacing={0.5}
+              sx={{
+                alignItems: 'center',
+              }}
+            >
+              <PeopleIcon fontSize="small" color="action" sx={{ mr: 0.5 }} />
               <Stack
                 direction="row"
                 spacing={0.5}
-                sx={{
-                  alignItems: 'center',
-                }}
+                sx={{ flexWrap: 'wrap', gap: 0.5 }}
               >
-                <PeopleIcon fontSize="small" color="action" sx={{ mr: 0.5 }} />
-                <Stack
-                  direction="row"
-                  spacing={0.5}
-                  sx={{ flexWrap: 'wrap', gap: 0.5 }}
-                >
-                  {prototype.users.map((user, index) => (
+                {prototype.users.map((user, index) => {
+                  const parsedUsername = parseUsername(user);
+                  const profileUrl = buildUserLink(
+                    parsedUsername.profileId || parsedUsername.displayName,
+                  );
+                  return profileUrl ? (
                     <Chip
                       key={index}
-                      label={user}
+                      label={formatUsername(parsedUsername)}
+                      size="small"
+                      variant="outlined"
+                      clickable
+                      component="a"
+                      href={profileUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    />
+                  ) : (
+                    <Chip
+                      key={index}
+                      label={formatUsername(parsedUsername)}
                       size="small"
                       variant="outlined"
                     />
-                  ))}
-                </Stack>
+                  );
+                })}
               </Stack>
-            )}
+            </Stack>
+          )}
 
-            {prototype.tags && prototype.tags.length > 0 && (
+          {prototype.tags && prototype.tags.length > 0 && (
+            <Stack
+              direction="row"
+              spacing={0.5}
+              sx={{
+                alignItems: 'center',
+              }}
+            >
+              <LocalOfferIcon
+                fontSize="small"
+                color="action"
+                sx={{ mr: 0.5 }}
+              />
               <Stack
                 direction="row"
                 spacing={0.5}
-                sx={{
-                  alignItems: 'center',
-                }}
+                sx={{ flexWrap: 'wrap', gap: 0.5 }}
               >
-                <LocalOfferIcon
-                  fontSize="small"
-                  color="action"
-                  sx={{ mr: 0.5 }}
-                />
-                <Stack
-                  direction="row"
-                  spacing={0.5}
-                  sx={{ flexWrap: 'wrap', gap: 0.5 }}
-                >
-                  {prototype.tags.map((tag, index) => (
-                    <Chip
-                      key={index}
-                      label={tag}
-                      size="small"
-                      color="primary"
-                    />
-                  ))}
-                </Stack>
+                {prototype.tags.map((tag, index) => (
+                  <Chip key={index} label={tag} size="small" color="primary" />
+                ))}
               </Stack>
-            )}
+            </Stack>
+          )}
 
-            {prototype.events && prototype.events.length > 0 && (
+          {prototype.events && prototype.events.length > 0 && (
+            <Stack
+              direction="row"
+              spacing={0.5}
+              sx={{
+                alignItems: 'center',
+              }}
+            >
+              <EventIcon fontSize="small" color="action" sx={{ mr: 0.5 }} />
               <Stack
                 direction="row"
                 spacing={0.5}
-                sx={{
-                  alignItems: 'center',
-                }}
+                sx={{ flexWrap: 'wrap', gap: 0.5 }}
               >
-                <EventIcon fontSize="small" color="action" sx={{ mr: 0.5 }} />
-                <Stack
-                  direction="row"
-                  spacing={0.5}
-                  sx={{ flexWrap: 'wrap', gap: 0.5 }}
-                >
-                  {prototype.events.map((event, index) => (
-                    <Chip
-                      key={index}
-                      label={event}
-                      size="small"
-                      color="secondary"
-                    />
-                  ))}
-                </Stack>
+                {prototype.events.map((event, index) => (
+                  <Chip
+                    key={index}
+                    label={event}
+                    size="small"
+                    color="secondary"
+                  />
+                ))}
               </Stack>
-            )}
+            </Stack>
+          )}
 
-            {prototype.materials && prototype.materials.length > 0 && (
+          {prototype.materials && prototype.materials.length > 0 && (
+            <Stack
+              direction="row"
+              spacing={0.5}
+              sx={{
+                alignItems: 'center',
+              }}
+            >
+              <CategoryIcon fontSize="small" color="action" sx={{ mr: 0.5 }} />
               <Stack
                 direction="row"
                 spacing={0.5}
-                sx={{
-                  alignItems: 'center',
-                }}
+                sx={{ flexWrap: 'wrap', gap: 0.5 }}
               >
-                <CategoryIcon
-                  fontSize="small"
-                  color="action"
-                  sx={{ mr: 0.5 }}
-                />
-                <Stack
-                  direction="row"
-                  spacing={0.5}
-                  sx={{ flexWrap: 'wrap', gap: 0.5 }}
-                >
-                  {prototype.materials.map((material, index) => (
-                    <Chip key={index} label={material} size="small" />
-                  ))}
-                </Stack>
+                {prototype.materials.map((material, index) => (
+                  <Chip key={index} label={material} size="small" />
+                ))}
               </Stack>
-            )}
-          </Stack>
-        </CardContent>
-      </CardActionArea>
+            </Stack>
+          )}
+        </Stack>
+      </CardContent>
       {prototype.mainUrl && (
         <CardActions>
           <Button
             // variant="contained"
             endIcon={<OpenInNewIcon />}
-            href={prototype.mainUrl}
+            href={buildPrototypeLink(prototype.id)}
             target="_blank"
             rel="noopener noreferrer"
             // sx={{ mb: 2 }}

--- a/src/components/common/prototype-card.tsx
+++ b/src/components/common/prototype-card.tsx
@@ -82,7 +82,7 @@ export function PrototypeCard({ prototype }: PrototypeCardProps) {
             </Stack>
           )}
 
-          {/* Users  */}
+          {/* Users */}
           {prototype.users && prototype.users.length > 0 && (
             <Stack
               direction="row"

--- a/src/components/common/prototype-card.tsx
+++ b/src/components/common/prototype-card.tsx
@@ -66,7 +66,7 @@ export function PrototypeCard({ prototype }: PrototypeCardProps) {
         )}
 
         <Stack spacing={1.5} sx={{ mt: 2 }}>
-          {/* Teamm */}
+          {/* Team */}
           {prototype.teamNm && (
             <Stack
               direction="row"

--- a/src/components/common/prototype-card.tsx
+++ b/src/components/common/prototype-card.tsx
@@ -99,7 +99,9 @@ export function PrototypeCard({ prototype }: PrototypeCardProps) {
               >
                 {prototype.users.map((user, index) => {
                   const parsedUsername = parseUsername(user);
-                  const profileUrl = buildUserLink(parsedUsername.profileId ?? '');
+                  const profileUrl = buildUserLink(
+                    parsedUsername.profileId ?? '',
+                  );
                   return profileUrl ? (
                     <Chip
                       key={index}
@@ -198,20 +200,18 @@ export function PrototypeCard({ prototype }: PrototypeCardProps) {
           )}
         </Stack>
       </CardContent>
-      {prototype.mainUrl && (
-        <CardActions>
-          <Button
-            // variant="contained"
-            endIcon={<OpenInNewIcon />}
-            href={buildPrototypeLink(prototype.id)}
-            target="_blank"
-            rel="noopener noreferrer"
-            // sx={{ mb: 2 }}
-          >
-            View on ProtoPedia
-          </Button>
-        </CardActions>
-      )}
+      <CardActions>
+        <Button
+          // variant="contained"
+          endIcon={<OpenInNewIcon />}
+          href={buildPrototypeLink(prototype.id)}
+          target="_blank"
+          rel="noopener noreferrer"
+          // sx={{ mb: 2 }}
+        >
+          View on ProtoPedia
+        </Button>
+      </CardActions>
     </Card>
   );
 }

--- a/src/utils/link.ts
+++ b/src/utils/link.ts
@@ -1,0 +1,22 @@
+const PROTOPEDIA_PROTOTYPE_BASE_URL = 'https://protopedia.net/prototype';
+export const buildPrototypeLink = (prototypeId: number): string => {
+  return `${PROTOPEDIA_PROTOTYPE_BASE_URL}/${prototypeId}`;
+};
+
+const PROTOPEDIA_TAG_BASE_URL = 'https://protopedia.net/tag';
+export const buildTagLink = (tag: string): string => {
+  const url = new URL(PROTOPEDIA_TAG_BASE_URL);
+  url.searchParams.set('tag', tag);
+  return url.toString();
+};
+
+const PROTOPEDIA_MATERIAL_BASE_URL = 'https://protopedia.net/material';
+export const buildMaterialLink = (material: string): string => {
+  return `${PROTOPEDIA_MATERIAL_BASE_URL}/${encodeURIComponent(material)}`;
+};
+
+const PROTOPEDIA_PROTOTYPER_BASE_URL = 'https://protopedia.net/prototyper';
+export const buildUserLink = (profileId: string): string | null => {
+  if (profileId === '') return null;
+  return `${PROTOPEDIA_PROTOTYPER_BASE_URL}/${encodeURIComponent(profileId)}`;
+};


### PR DESCRIPTION
## 概要

promidas 系 demo サイトとして、`promidas-utils` の新機能 **`parseUsername`** (v3.2.0 追加) を採用し、プロトタイプカードの著者表示を強化します。

## 変更内容

### 著者表示 (parseUsername)
- 各著者 (`displayName@profileId`) を `parseUsername` で分解し、**`displayName (profileId)`** 形式で表示
- `buildUserLink` で著者の ProtoPedia プロフィール (`/prototyper/{profileId}`) へリンク
- 表示名が空 (~20%) のケースは `@profileId` にフォールバック

### その他のカード改善
- `teamNm` があればチーム名を表示 (Groups アイコン付き)
- 「View on ProtoPedia」ボタンの URL を `buildPrototypeLink(id)` で生成

### 構造修正: `CardActionArea` 撤去
- `onClick`/`href` を持たない**機能しない `CardActionArea`** を削除
- これがコンテンツをラップし、著者リンク (`<a>`) を `<button>` 内にネスト = **無効な HTML** だった問題を解消 (DOM 実測で確認)
- 「押せそうで押せない」誤誘導も解消

### 補助
- `src/utils/link.ts` に ProtoPedia URL ビルダーを追加
- `UserNameVariations` ストーリーで各パースパターン (通常/表示名なし/`@`含み/`@`なし) を可視化
- `CHANGELOG.md` の `[Unreleased]` に promidas 系更新を記載

## 検証

- `npm run build` (tsc 込み) ✓
- `npm test` (167 passed) ✓
- `npm run lint` ✓
- `npm run format:check` ✓
- Storybook で目視確認済み
- 著者リンクが `<button>` の外にあることを DOM 検査で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)