### PR TITLE
chore(release): 2026.07.07

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [CalVer](https://calver.org/).
 
-## [Unreleased]
+## [2026.07.07] - 2026-07-07
 
 ### PROMIDAS versions
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "promidas-demo",
-  "version": "2026.01.28",
+  "version": "2026.07.07",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "promidas-demo",
-      "version": "2026.01.28",
+      "version": "2026.07.07",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "promidas-demo",
   "private": true,
-  "version": "2026.01.28",
+  "version": "2026.07.07",
   "type": "module",
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
## 概要

CalVer に従いバージョンを `2026.01.28` -> `2026.07.07` に更新し、CHANGELOG の `[Unreleased]` を `[2026.07.07]` として確定します。

## 変更内容

- `package.json` / `package-lock.json` の version を `2026.07.07` に
- `CHANGELOG.md` の `[Unreleased]` を `## [2026.07.07] - 2026-07-07` に変換

## このリリースに含まれる PROMIDAS 系更新 (2026.01.28 以降)

- `promidas` 3.0.0 -> 3.0.1
- `promidas-utils` 3.0.0 -> 3.2.1
- `promidas-utils` の `parseUsername` を prototype card に採用

## 検証

- `npm run build` ✓ / `npm test` (167 passed) ✓ / `npm run lint` ✓ / `npm run format:check` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)