### PR TITLE
fix(repository): correct disabled state for inputs and buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [CalVer](https://calver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Keep the input field editable when its value is emptied in the
+  `getPrototypeFromSnapshotByPrototypeId` and `getRandomSampleFromSnapshot`
+  sections. Previously clearing the value disabled the field itself and
+  trapped the user.
+- Disable the execute button while the input is empty in the
+  `getRandomSampleFromSnapshot` section, matching
+  `getPrototypeFromSnapshotByPrototypeId`.
+
 ## [2026.07.07] - 2026-07-07
 
 ### PROMIDAS versions

--- a/src/components/repository/random-prototype.tsx
+++ b/src/components/repository/random-prototype.tsx
@@ -49,7 +49,13 @@ export function RandomPrototype({
     fetchRandom(size);
   };
 
-  const disabled = randomLoading || getStoreState(stats) === 'not-stored';
+  // The input field must stay editable even when empty, so it only reacts to
+  // loading and store availability - not to whether a value is present.
+  const inputDisabled =
+    randomLoading || getStoreState(stats) === 'not-stored';
+
+  // The execute button additionally requires a non-empty value.
+  const fetchDisabled = inputDisabled || randomSampleSize.trim() === '';
 
   return (
     <SectionCard
@@ -65,7 +71,7 @@ export function RandomPrototype({
         }}
       >
         <TextField
-          disabled={disabled}
+          disabled={inputDisabled}
           label="件数"
           type="number"
           value={randomSampleSize}
@@ -89,13 +95,13 @@ export function RandomPrototype({
       >
         <ActionButton
           onClick={handleFetchRandom}
-          disabled={disabled}
+          disabled={fetchDisabled}
           loading={randomLoading}
         >
           実行
         </ActionButton>
         <ActionButton
-          disabled={disabled || randomPrototypes.length === 0}
+          disabled={inputDisabled || randomPrototypes.length === 0}
           onClick={clearRandom}
           variant="secondary"
         >

--- a/src/components/repository/search-by-id.tsx
+++ b/src/components/repository/search-by-id.tsx
@@ -47,10 +47,13 @@ export function SearchById({ stats, onUseSnapshot }: SearchByIdProps) {
     }
   };
 
-  const disabled =
-    searchLoading ||
-    searchId.trim() === '' ||
-    getStoreState(stats) === 'not-stored';
+  // The input field must stay editable even when empty, so it only reacts to
+  // loading and store availability - not to whether a value is present.
+  const inputDisabled =
+    searchLoading || getStoreState(stats) === 'not-stored';
+
+  // The execute button additionally requires a non-empty value.
+  const searchDisabled = inputDisabled || searchId.trim() === '';
 
   return (
     <SectionCard
@@ -66,7 +69,7 @@ export function SearchById({ stats, onUseSnapshot }: SearchByIdProps) {
         }}
       >
         <TextField
-          disabled={disabled}
+          disabled={inputDisabled}
           label="ID"
           type="number"
           value={searchId}
@@ -87,7 +90,7 @@ export function SearchById({ stats, onUseSnapshot }: SearchByIdProps) {
         }}
       >
         <ActionButton
-          disabled={disabled}
+          disabled={searchDisabled}
           onClick={handleSearch}
           loading={searchLoading}
         >
@@ -95,7 +98,6 @@ export function SearchById({ stats, onUseSnapshot }: SearchByIdProps) {
         </ActionButton>
         <ActionButton
           disabled={!searchPrototype}
-          // disabled={disabled}
           onClick={clearSearch}
           variant="secondary"
         >


### PR DESCRIPTION
## 概要

`getPrototypeFromSnapshotByPrototypeId`(`SearchById`) と `getRandomSampleFromSnapshot`(`RandomPrototype`) の入力欄・ボタンの disabled 判定を修正しました。

## 背景 / 問題

- 入力欄とボタンで同じ `disabled` 条件（空チェックを含む）を共有していたため、**ID / 件数を空にすると入力欄自体が無効化され、再入力できなくなる**不具合があった。
- `getRandomSampleFromSnapshot` では件数が空でも実行ボタンが有効なままだった。

## 変更内容

- **入力欄用とボタン用で disabled 条件を分離**
  - 入力欄 (`inputDisabled`): ローディング中 / ストア未保存のときのみ無効。空でも編集可能。
  - 実行ボタン: 上記に加えて値が空なら無効。
- **SearchById のクリアボタン**: 「クリア＝表示結果の破棄」というセマンティクスに合わせ、`disabled={!searchPrototype}`（表示結果の有無のみ）に整理。入力値には依存しない。
- **RandomPrototype**: 件数が空のとき実行ボタンを無効化し、`SearchById` と挙動を統一。
- `CHANGELOG.md` の `## [Unreleased]` に `### Fixed` として追記。

🤖 Generated with [Claude Code](https://claude.com/claude-code)