### PR TITLE
feat: add ProtoPedia CC BY 4.0 attribution (footer + README)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Footer: add a data attribution notice ("This site uses data from ProtoPedia
+  (CC BY 4.0)") with links to ProtoPedia and the CC BY 4.0 license.
+- README: add a "Data Source & License" section documenting that the app uses
+  ProtoPedia data retrieved through the ProtoPedia API (v2), and that ProtoPedia
+  applies the CC BY 4.0 license to registered work information by default
+  (English and Japanese).
+
 ## 2026-07-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -75,3 +75,15 @@ MIT
 - [PROMIDAS](https://github.com/F88/promidas)
 - [ProtoPedia](https://protopedia.net/)
 - [ProtoPedia API v2](https://protopediav2.docs.apiary.io/)
+
+## Data Source & License / データ出典とライセンス
+
+### ProtoPedia Data / ProtoPedia のデータ
+
+This application uses data from [ProtoPedia](https://protopedia.net/), retrieved through the [ProtoPedia API Ver 2.0](https://protopediav2.docs.apiary.io/).
+ProtoPedia applies the [Creative Commons Attribution 4.0 International (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/deed.en) license to registered work information by default.
+
+本アプリケーションは、[ProtoPedia](https://protopedia.net/)の作品情報を [ProtoPedia API Ver 2.0](https://protopediav2.docs.apiary.io/) を通じて取得し、利用しています。
+ProtoPediaでは、登録作品情報に [クリエイティブ・コモンズ 表示 4.0 国際(CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/deed.ja) ライセンスが標準適用されています。
+
+Reference: [ProtoPedia Help Center](https://protopedia.gitbook.io/helpcenter/info/2022.05.23)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -396,6 +396,27 @@ function App() {
             PROMIDAS
           </Link>
         </Typography>
+        <Typography variant="body2" sx={{ mt: 0.5 }}>
+          This site uses data from{' '}
+          <Link
+            href="https://protopedia.net/"
+            target="_blank"
+            rel="noopener noreferrer"
+            sx={{ color: 'white', fontWeight: 600 }}
+          >
+            ProtoPedia
+          </Link>{' '}
+          (
+          <Link
+            href="https://creativecommons.org/licenses/by/4.0/"
+            target="_blank"
+            rel="noopener noreferrer"
+            sx={{ color: 'white', fontWeight: 600 }}
+          >
+            CC BY 4.0
+          </Link>
+          ).
+        </Typography>
       </Box>
     </Box>
   );


### PR DESCRIPTION
## Summary

Add ProtoPedia data attribution so the demo site meets the CC BY 4.0
attribution requirement.

- **Footer** (`src/App.tsx`): add a notice
  `This site uses data from ProtoPedia (CC BY 4.0).` with links to
  [ProtoPedia](https://protopedia.net/) and the
  [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) license. This is the
  primary attribution, shown in the medium where the content is actually
  displayed to visitors.
- **README** (`## データ出典とライセンス`): document that the app uses ProtoPedia
  data via the ProtoPedia API (v2), and that ProtoPedia applies CC BY 4.0 to
  registered work information by default.

## Notes

- ProtoPedia applies CC BY 4.0 to registered work information by default;
  authors can opt out per work. Data retrieved through the API is therefore used
  under CC BY 4.0, which requires an attribution + license notice where the
  content is shared.
- `tsc -b` and `eslint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)