### PR TITLE
chore(release): 2026.07.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ## [Unreleased]
 
+## 2026-07-21
+
 ### Added
 
 - Footer: add a data attribution notice ("This site uses data from ProtoPedia

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "promidas-demo",
-  "version": "2026.07.15",
+  "version": "2026.07.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "promidas-demo",
-      "version": "2026.07.15",
+      "version": "2026.07.21",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "promidas-demo",
   "private": true,
-  "version": "2026.07.15",
+  "version": "2026.07.21",
   "type": "module",
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
## Summary

- Bump version `2026.07.15` → `2026.07.21` (CalVer)
- Finalize CHANGELOG `[Unreleased]` as `## 2026-07-21`
  - ProtoPedia CC BY 4.0 attribution (Footer + README)

🤖 Generated with [Claude Code](https://claude.com/claude-code)