### PR TITLE
feat(fetcher): forward HTTP status from progress events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ## [Unreleased]
 
+### PROMIDAS versions
+
+- Upgraded `promidas` to `v3.1.0`.
+
+### Changed
+
+- Forward the HTTP status carried by `FetchProgressEvent` (added in `promidas`
+  v3.1.0) through the download-progress pipeline. A completed transfer with a
+  non-2xx status is now shown as an error response
+  ("Error response body received (HTTP xxx)") instead of "Download complete",
+  so an error body (e.g. a 401 JSON payload) is no longer reported as a
+  successful fetch.
+
 ## 2026-07-21
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -8805,9 +8805,9 @@
       "peer": true
     },
     "node_modules/promidas": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/promidas/-/promidas-3.0.1.tgz",
-      "integrity": "sha512-mukwev1pfsRz8iYaBvF7w1xTmx5BwZUuyddC2THh0baTm0kcSge3btRvN8oMu8YO2YCBnmDdFShjcq30VY4X1Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/promidas/-/promidas-3.1.0.tgz",
+      "integrity": "sha512-z29p+Ea7TehomQVJDa7LfyM4x7nJB4AoQ0xfSKE11ZxV8owEMBvX7YbE5D6DZOT/t83kT+DUqj9ulQ3SGGNMwA==",
       "license": "MIT",
       "dependencies": {
         "events": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^9.2.0",
     "@mui/material": "^9.2.0",
-    "promidas": "^3.0.1",
+    "promidas": "^3.1.0",
     "promidas-utils": "^3.2.1",
     "protopedia-api-v2-client": "^3.0.0",
     "react": "^19.2.7",

--- a/src/components/fetcher/fetcher-container.tsx
+++ b/src/components/fetcher/fetcher-container.tsx
@@ -69,6 +69,15 @@ export function FetcherContainer() {
           progress.totalTimeMs !== undefined
             ? (progress.totalTimeMs / 1000).toFixed(2)
             : 'N/A';
+        // A completed body transfer is not necessarily a successful fetch.
+        // For a non-2xx response the body (e.g. an error JSON payload) still
+        // finishes downloading, so distinguish it from a success (see #126).
+        const isHttpError =
+          progress.httpStatus !== undefined &&
+          (progress.httpStatus < 200 || progress.httpStatus >= 300);
+        if (isHttpError) {
+          return `[${time}] ⚠️ Error response body received (HTTP ${progress.httpStatus}): ${progress.receivedBytes ?? 0} bytes in ${downloadTimeS}s (total: ${totalTimeS}s)`;
+        }
         return `[${time}] ✅ Download complete: ${progress.receivedBytes ?? 0} bytes received (estimated ${progress.estimatedBytes ?? 0} bytes) in ${downloadTimeS}s (total: ${totalTimeS}s)`;
       }
       case 'error':
@@ -116,7 +125,11 @@ export function FetcherContainer() {
                       progress.status === 'error'
                         ? 'error'
                         : progress.status === 'completed'
-                          ? 'success.main'
+                          ? progress.httpStatus !== undefined &&
+                            (progress.httpStatus < 200 ||
+                              progress.httpStatus >= 300)
+                            ? 'warning.main'
+                            : 'success.main'
                           : progress.status === 'started'
                             ? 'warning.main'
                             : progress.status === 'in-progress'

--- a/src/hooks/use-download-progress.ts
+++ b/src/hooks/use-download-progress.ts
@@ -17,6 +17,8 @@ interface DownloadProgress {
   limit?: number;
   increment?: number;
   errorMessage?: string;
+  /** HTTP status code of the response (available once headers arrive). */
+  httpStatus?: number;
   timestamp: number;
 }
 

--- a/src/lib/repository/__tests__/repository-config.test.ts
+++ b/src/lib/repository/__tests__/repository-config.test.ts
@@ -103,18 +103,21 @@ describe('repository-config', () => {
         cb({ type: 'request-start' });
         cb({
           type: 'response-received',
+          status: 200,
           estimatedTotal: 100,
           limit: 200,
           prepareTimeMs: 1234,
         });
         cb({
           type: 'download-progress',
+          status: 200,
           received: 10,
           total: 100,
           percentage: 10,
         });
         cb({
           type: 'complete',
+          status: 200,
           received: 100,
           estimatedTotal: 100,
           downloadTimeMs: 2345,
@@ -123,6 +126,7 @@ describe('repository-config', () => {
 
         expect(mocks.emitDownloadProgress).toHaveBeenCalledWith({
           status: 'started',
+          httpStatus: 200,
           estimatedBytes: 100,
           limit: 200,
           prepareTimeMs: 1234,
@@ -130,6 +134,7 @@ describe('repository-config', () => {
 
         expect(mocks.emitDownloadProgress).toHaveBeenCalledWith({
           status: 'in-progress',
+          httpStatus: 200,
           receivedBytes: 10,
           estimatedBytes: 100,
           percentage: 10,
@@ -137,10 +142,51 @@ describe('repository-config', () => {
 
         expect(mocks.emitDownloadProgress).toHaveBeenCalledWith({
           status: 'completed',
+          httpStatus: 200,
           receivedBytes: 100,
           estimatedBytes: 100,
           downloadTimeMs: 2345,
           totalTimeMs: 3456,
+        });
+      });
+
+      it('forwards a non-2xx HTTP status on a completed error body (#126)', async () => {
+        const { apiClientConfig } = await createRepositoryConfigs(
+          'token',
+          'debug',
+        );
+        const cb = apiClientConfig.progressCallback;
+
+        if (!cb) {
+          throw new Error('Expected progressCallback to be defined');
+        }
+
+        // A 401 error body (e.g. 97-byte JSON) still finishes downloading:
+        // the transport reports a completed transfer carrying status 401.
+        cb({ type: 'request-start' });
+        cb({
+          type: 'response-received',
+          status: 401,
+          estimatedTotal: 25_000_000,
+          limit: 100,
+          prepareTimeMs: 100,
+        });
+        cb({
+          type: 'complete',
+          status: 401,
+          received: 97,
+          estimatedTotal: 25_000_000,
+          downloadTimeMs: 119,
+          totalTimeMs: 200,
+        });
+
+        expect(mocks.emitDownloadProgress).toHaveBeenCalledWith({
+          status: 'completed',
+          httpStatus: 401,
+          receivedBytes: 97,
+          estimatedBytes: 25_000_000,
+          downloadTimeMs: 119,
+          totalTimeMs: 200,
         });
       });
     });
@@ -160,18 +206,21 @@ describe('repository-config', () => {
         cb({ type: 'request-start' });
         cb({
           type: 'response-received',
+          status: 200,
           estimatedTotal: 50000,
           limit: 100,
           prepareTimeMs: 500,
         });
         cb({
           type: 'download-progress',
+          status: 200,
           received: 12345,
           total: 50000,
           percentage: 24.69,
         });
         cb({
           type: 'error',
+          status: 200,
           error: 'Network error occurred',
           received: 12345,
           estimatedTotal: 50000,
@@ -181,6 +230,7 @@ describe('repository-config', () => {
 
         expect(mocks.emitDownloadProgress).toHaveBeenCalledWith({
           status: 'error',
+          httpStatus: 200,
           errorMessage: 'Network error occurred',
           receivedBytes: 12345,
           estimatedBytes: 50000,

--- a/src/lib/repository/repository-config.ts
+++ b/src/lib/repository/repository-config.ts
@@ -57,12 +57,14 @@ export async function createRepositoryConfigs(
           break;
         case 'response-received':
           console.info('[Download Progress] Started', {
+            httpStatus: event.status,
             estimatedBytes: event.estimatedTotal,
             limit: event.limit,
             prepareTimeMs: event.prepareTimeMs,
           });
           emitDownloadProgress({
             status: 'started',
+            httpStatus: event.status,
             estimatedBytes: event.estimatedTotal,
             limit: event.limit,
             prepareTimeMs: event.prepareTimeMs,
@@ -70,12 +72,14 @@ export async function createRepositoryConfigs(
           break;
         case 'download-progress':
           console.info('[Download Progress] In progress', {
+            httpStatus: event.status,
             receivedBytes: event.received,
             totalBytes: event.total,
             percentage: event.percentage,
           });
           emitDownloadProgress({
             status: 'in-progress',
+            httpStatus: event.status,
             receivedBytes: event.received,
             estimatedBytes: event.total,
             percentage: event.percentage,
@@ -83,6 +87,7 @@ export async function createRepositoryConfigs(
           break;
         case 'complete':
           console.info('[Download Progress] Completed', {
+            httpStatus: event.status,
             receivedBytes: event.received,
             estimatedBytes: event.estimatedTotal,
             downloadTimeMs: event.downloadTimeMs,
@@ -90,6 +95,7 @@ export async function createRepositoryConfigs(
           });
           emitDownloadProgress({
             status: 'completed',
+            httpStatus: event.status,
             receivedBytes: event.received,
             estimatedBytes: event.estimatedTotal,
             downloadTimeMs: event.downloadTimeMs,
@@ -98,6 +104,7 @@ export async function createRepositoryConfigs(
           break;
         case 'error':
           console.error('[Download Progress] Error', {
+            httpStatus: event.status,
             error: event.error,
             receivedBytes: event.received,
             estimatedBytes: event.estimatedTotal,
@@ -106,6 +113,7 @@ export async function createRepositoryConfigs(
           });
           emitDownloadProgress({
             status: 'error',
+            httpStatus: event.status,
             errorMessage: event.error,
             receivedBytes: event.received,
             estimatedBytes: event.estimatedTotal,


### PR DESCRIPTION
## Summary

Adopts promidas `3.1.0` ([F88/promidas#128](https://github.com/F88/promidas/pull/128)), which adds a required `status` field to `FetchProgressEvent` variants that fire after response headers arrive. This lets the demo distinguish a completed transfer of an *error* body (e.g. a 97-byte 401 JSON payload) from a successful fetch, instead of reporting "Download complete" for error responses.

Closes the demo-side follow-up to [F88/promidas#126](https://github.com/F88/promidas/issues/126).

## Changes

- **Dependency**: `promidas` `^3.0.1` -> `^3.1.0` (`package.json` / `package-lock.json`)
- **`src/hooks/use-download-progress.ts`**: add `httpStatus?: number` to `DownloadProgress`
- **`src/lib/repository/repository-config.ts`**: forward `event.status` from the `response-received` / `download-progress` / `complete` / `error` events into `emitDownloadProgress` and the console logs
- **`src/components/fetcher/fetcher-container.tsx`**: a completed transfer with a non-2xx `httpStatus` now renders as `⚠️ Error response body received (HTTP xxx)` in the warning color instead of `✅ Download complete` in the success color
- **Tests**: supply `status` on the mock events (now required), assert `httpStatus` is forwarded, and add a new test reproducing the #126 scenario (a 401 error body completing with `status: 401`)

## Verification

- `tsc -b`: clean
- `vitest run`: 16 files / 168 tests passed
- `eslint .`: clean

Refs: F88/promidas#126

🤖 Generated with [Claude Code](https://claude.com/claude-code)