### PR TITLE
chore(release): 2026.07.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ## [Unreleased]
 
+## 2026-07-22
+
 ### PROMIDAS versions
 
 - Upgraded `promidas` to `v3.1.0`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "promidas-demo",
-  "version": "2026.07.21",
+  "version": "2026.07.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "promidas-demo",
-      "version": "2026.07.21",
+      "version": "2026.07.22",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "promidas-demo",
   "private": true,
-  "version": "2026.07.21",
+  "version": "2026.07.22",
   "type": "module",
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
## Release 2026.07.22

CalVer bump `2026.07.21` -> `2026.07.22`.

### PROMIDAS versions

- Upgraded `promidas` to `v3.1.0`.

### Changed

- Forward the HTTP status carried by `FetchProgressEvent` (added in `promidas` v3.1.0) through the download-progress pipeline. A completed transfer with a non-2xx status is now shown as an error response instead of "Download complete", so an error body (e.g. a 401 JSON payload) is no longer reported as a successful fetch.

Follows #77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)