### PR TITLE
feat(security): add Content Security Policy

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,7 +9,7 @@ import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
 export default defineConfig([
-  globalIgnores(['dist', '!.storybook']),
+  globalIgnores(['dist', 'storybook-static', '!.storybook']),
   js.configs.recommended,
   ...tseslint.configs.recommended,
   {

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>🛝 PROMIDAS Playground</title>
   </head>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <text
+    x="16"
+    y="16"
+    font-size="26"
+    text-anchor="middle"
+    dominant-baseline="central"
+  >🛝</text>
+</svg>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,108 @@
 /// <reference types="vitest/config" />
 import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
+
+/**
+ * Builds the Content Security Policy for the given environment.
+ *
+ * The app loads no remote images, fonts, iframes or workers, so everything
+ * except the ProtoPedia API endpoint can be denied. The dev server needs two
+ * relaxations: inline scripts for the React Fast Refresh preamble, and its HMR
+ * WebSocket. The http(s) origins reachable through `connect-src` and `img-src`
+ * are the same in both modes, so exfiltration behaves identically there.
+ *
+ * Delivery differs per environment: GitHub Pages serves static files only and
+ * cannot set response headers, so the production policy travels in a
+ * `<meta http-equiv>` tag. Note that `frame-ancestors`, `report-uri`,
+ * `report-to` and `sandbox` are ignored when delivered that way, and
+ * `Content-Security-Policy-Report-Only` is not available at all.
+ */
+function buildContentSecurityPolicy(
+  mode: 'production' | 'development',
+): string {
+  const isDev = mode === 'development';
+
+  return [
+    // Deny anything not explicitly listed below, including future directives.
+    "default-src 'none'",
+    // Bundled scripts only. Blocks injected inline and remote scripts.
+    // The dev server injects the React Fast Refresh preamble inline, so
+    // 'unsafe-inline' is unavoidable there.
+    `script-src 'self'${isDev ? " 'unsafe-inline'" : ''}`,
+    // MUI (Emotion) injects <style> elements at runtime, so inline styles are
+    // unavoidable here.
+    "style-src 'self' 'unsafe-inline'",
+    // The app renders no <img> elements; 'self' just covers same-origin assets
+    // such as a favicon. `data:` issues no network request, so neither source
+    // can be used to smuggle data out.
+    "img-src 'self' data:",
+    // The single legitimate destination for the API token. The dev server also
+    // needs its HMR WebSocket; the port is wildcarded because Vite picks the
+    // next free one when its default is taken (and --port overrides it), which
+    // would otherwise break HMR silently. Every other origin stays denied, so
+    // exfiltration behaviour is identical to production.
+    `connect-src 'self' https://protopedia.net${
+      isDev ? ' ws://localhost:*' : ''
+    }`,
+    // No form performs a real submission; the token form calls preventDefault().
+    "form-action 'none'",
+    // Prevents an injected <base> tag from rewriting relative URLs.
+    "base-uri 'none'",
+  ].join('; ');
+}
+
+/**
+ * Injects the CSP meta tag into `index.html` at build time.
+ *
+ * Build-only because the meta tag exists to work around GitHub Pages being
+ * unable to set response headers. The dev server can set them, so it serves the
+ * development policy through `server.headers` instead.
+ */
+function contentSecurityPolicyPlugin(): Plugin {
+  return {
+    name: 'inject-csp-meta',
+    apply: 'build',
+    transformIndexHtml(_html, ctx) {
+      // Storybook's react-vite framework merges this config and builds its own
+      // iframe.html through the same hook. That document needs inline scripts
+      // and framing, so restrict the policy to the app's own entry point.
+      if (ctx.path !== '/index.html') {
+        return [];
+      }
+
+      return [
+        {
+          tag: 'meta',
+          attrs: {
+            'http-equiv': 'Content-Security-Policy',
+            content: buildContentSecurityPolicy('production'),
+          },
+          // A meta policy only governs what follows it, so it must come first.
+          injectTo: 'head-prepend',
+        },
+      ];
+    },
+  };
+}
 
 // https://vite.dev/config/
 export default defineConfig({
   base: '/PROMIDAS-demo/',
-  plugins: [react()],
+  plugins: [react(), contentSecurityPolicyPlugin()],
+  server: {
+    // Unlike GitHub Pages, the dev server can set response headers, so the
+    // policy is delivered that way here rather than through the meta tag.
+    headers: {
+      'Content-Security-Policy': buildContentSecurityPolicy('development'),
+    },
+  },
+  preview: {
+    // `vite preview` would otherwise inherit server.headers and serve the
+    // development policy next to the production meta tag. Clearing it keeps
+    // preview a faithful stand-in for GitHub Pages, where the meta tag is the
+    // only policy in effect.
+    headers: {},
+  },
   build: {
     rollupOptions: {
       output: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,10 +6,12 @@ import { defineConfig, type Plugin } from 'vite';
  * Builds the Content Security Policy for the given environment.
  *
  * The app loads no remote images, fonts, iframes or workers, so everything
- * except the ProtoPedia API endpoint can be denied. The dev server needs two
- * relaxations: inline scripts for the React Fast Refresh preamble, and its HMR
- * WebSocket. The http(s) origins reachable through `connect-src` and `img-src`
- * are the same in both modes, so exfiltration behaves identically there.
+ * except the ProtoPedia API endpoint can be denied. The dev server needs a
+ * single relaxation: inline scripts for the React Fast Refresh preamble. Its
+ * HMR WebSocket needs no extra source, because `connect-src 'self'` already
+ * matches a ws:// URL on the page's own host and port. Every other directive,
+ * `connect-src` and `img-src` included, is identical in both modes, so
+ * exfiltration behaves the same way in development as in production.
  *
  * Delivery differs per environment: GitHub Pages serves static files only and
  * cannot set response headers, so the production policy travels in a
@@ -36,14 +38,11 @@ function buildContentSecurityPolicy(
     // such as a favicon. `data:` issues no network request, so neither source
     // can be used to smuggle data out.
     "img-src 'self' data:",
-    // The single legitimate destination for the API token. The dev server also
-    // needs its HMR WebSocket; the port is wildcarded because Vite picks the
-    // next free one when its default is taken (and --port overrides it), which
-    // would otherwise break HMR silently. Every other origin stays denied, so
-    // exfiltration behaviour is identical to production.
-    `connect-src 'self' https://protopedia.net${
-      isDev ? ' ws://localhost:*' : ''
-    }`,
+    // The single legitimate destination for the API token, in both modes. The
+    // dev server's HMR WebSocket needs no entry of its own: CSP matches a ws://
+    // URL against 'self', so it keeps working through whichever loopback
+    // hostname and port the page was reached on.
+    "connect-src 'self' https://protopedia.net",
     // No form performs a real submission; the token form calls preventDefault().
     "form-action 'none'",
     // Prevents an injected <base> tag from rewriting relative URLs.


### PR DESCRIPTION
## Summary

Adds a Content Security Policy to the demo app, plus two pre-existing defects found while working on it.

This app keeps a ProtoPedia API token in the browser, so the blast radius of any code execution is large. The CSP is defence in depth: it contains the damage rather than preventing the initial compromise.

## What changed

| Commit | Content |
|---|---|
| `feat(security)` | Content Security Policy (`vite.config.ts`) |
| `fix(security)` | Remove a needless `ws://` source from the dev policy |
| `fix(ui)` | Favicon reference pointing at a file that does not exist |
| `chore(lint)` | Missing eslint ignore entry |

### Content Security Policy

```
default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline';
img-src 'self' data:; connect-src 'self' https://protopedia.net;
form-action 'none'; base-uri 'none'
```

- GitHub Pages cannot set response headers, so the production policy travels in a `<meta http-equiv>` tag. That delivery method ignores `frame-ancestors`, `report-uri`, `report-to` and `sandbox`, and Report-Only mode is unavailable.
- The dev server gets the same policy as a real response header, with exactly one relaxation: inline scripts for the React Fast Refresh preamble. `connect-src` and `img-src` are byte-identical across both modes.
- Vite's HMR socket needs no source of its own. CSP matches a `ws://` URL against `'self'`, so the socket connects through whichever loopback hostname and port the page was reached on. Verified over both `http://localhost` and `http://[::1]`.
- Meta injection is limited to the app's own `index.html`. Storybook's react-vite framework merges this config and builds its own `iframe.html`, which needs inline scripts and framing.
- `preview.headers` is cleared so `vite preview` stops inheriting the dev header and mirrors GitHub Pages, where the meta tag is the only policy in effect.

### Favicon

`index.html` referenced `/vite.svg`, but no such file existed anywhere in the project. Vite only rewrites public asset URLs with the configured base when the file is present, so the reference stayed at `/vite.svg` and resolved to the origin root on GitHub Pages, returning 404.

`public/favicon.svg` now carries the emoji already used in the page title. Dropping the link instead would not have helped: browsers then request `/favicon.ico` at the origin root, which a project page cannot serve.

### eslint ignore

`storybook-static/` was missing from eslint's ignore list, so running `build-storybook` before `lint` surfaced errors from generated bundles. `.prettierignore` already excludes the directory, so eslint was the only tool still scanning it. CI is unaffected because it never runs `build-storybook`.

## Verification

Exfiltration attempts were fired at a local server and measured by whether they reached its access log, or by whether a `securitypolicyviolation` event fired. Results are identical in dev and preview.

| Channel | Without CSP | With CSP |
|---|---|---|
| `fetch()` | reached | **blocked** |
| `new Image().src` | reached | **blocked** |
| `navigator.sendBeacon()` | reached | **blocked** |
| `new WebSocket()` to a local port | reached | **blocked** |
| `location.href` | reached | reached |

Note that `sendBeacon()` returns `true` even when the request is blocked; only server-side logs reveal what actually went out.

Also confirmed:

- The app renders correctly with zero CSP violations in the console.
- HMR stays connected (`[vite] connected.`) over `localhost` and `[::1]`.
- A real token successfully reaches the ProtoPedia API under the policy.
- `build-storybook` output carries no CSP meta, and the Storybook dev server receives no CSP header.
- `npm test` passes: 16 files, 168 tests.
- `<meta charset>` sits at byte 343, well inside the 1024-byte requirement.

## Known limitation

**Top-level navigation via `location.href` is not blocked by CSP.** No directive covers it (`navigate-to` was removed from the spec). The follow-on Referer exposure on the destination page remains for the same reason.

This PR therefore does not prevent token theft. What it does:

- Downgrades silent, unlimited, continuous exfiltration to a single visible page navigation carrying a few KB.
- Provides the only runtime defence against malicious code bundled through a compromised dependency, which `script-src 'self'` cannot stop because the code ships as first-party JavaScript.

Preventing code execution in the first place remains the primary control: no XSS sinks, and disciplined dependency management.

🤖 Generated with [Claude Code](https://claude.com/claude-code)