### PR TITLE
feat(security): make the API token field write-only

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -93,15 +93,12 @@ function PromidasInfoSection() {
 }
 
 function App() {
-  const { token, hasToken, saveToken, removeToken } = useToken();
+  const { hasToken, saveToken, removeToken } = useToken();
   const resetRepositoryInstance = useResetProtopediaRepository();
+  // Write-only field. A stored token is deliberately never restored into the
+  // input, so the raw value stays out of the DOM; `hasToken` tells the user
+  // whether one is set. Requests read the token straight from storage.
   const [tokenInput, setTokenInput] = useState('');
-
-  useEffect(() => {
-    queueMicrotask(() => {
-      setTokenInput(token ?? '');
-    });
-  }, [token]);
 
   // Data flow visualization
   const {
@@ -212,6 +209,10 @@ function App() {
   const handleSaveToken = async () => {
     if (tokenInput.trim()) {
       await saveToken(tokenInput.trim());
+      // Clear the field once the token is stored so the raw value stops
+      // lingering in the DOM, and so a saved token always looks the same
+      // whether or not the page has been reloaded since.
+      setTokenInput('');
       resetRepositoryInstance();
       showStoreInfo();
     }

--- a/src/components/config/token-configuration.tsx
+++ b/src/components/config/token-configuration.tsx
@@ -61,7 +61,9 @@ export function TokenConfiguration({
           type={showToken ? 'text' : 'password'}
           value={token}
           onChange={(e) => setToken(e.target.value)}
-          placeholder="ProtoPedia APIトークン"
+          placeholder={
+            hasToken ? '設定済み (再入力で上書き)' : 'ProtoPedia APIトークン'
+          }
           size="small"
           sx={{ mb: 2 }}
           name="protopedia_api_token"
@@ -76,6 +78,9 @@ export function TokenConfiguration({
                 <InputAdornment position="end">
                   <IconButton
                     onClick={() => setShowToken(!showToken)}
+                    // The field is write-only, so it is empty until the user
+                    // types. Toggling visibility on an empty field does nothing.
+                    disabled={!token}
                     edge="end"
                     aria-label={showToken ? 'Hide token' : 'Show token'}
                     size="small"


### PR DESCRIPTION
## Summary

The API token input was repopulated from storage on mount, so the raw token sat in the DOM for the entire session. This makes the field write-only: it holds a value only while the user is entering one.

Follow-up to #79, which added the CSP.

## The problem

`App.tsx` restored the stored token into the input on every mount:

```tsx
useEffect(() => {
  queueMicrotask(() => {
    setTokenInput(token ?? '');
  });
}, [token]);
```

That value flows into `<TextField value={...}>`, so the raw token was readable with one line:

```js
document.getElementById('protopedia_api_token').value
```

`type="password"` does not help here. Masking is a display concern; the DOM property holds the plain value either way, which was confirmed by reading it back while the field was still masked.

## Changes

- Drop the restore effect, and clear the field after a successful save. The raw value now exists in the DOM only between typing it and storing it.
- Switch the placeholder on `hasToken`, so a stored token is reported as `設定済み (再入力で上書き)` rather than shown.
- Disable the visibility toggle while the field is empty, since it has nothing to reveal. It still works during entry, which is when checking a pasted value matters.

This matches how GitHub, AWS and Stripe treat API keys: shown once at entry, never rendered back. It also removes an inconsistency, since a saved token now looks the same whether or not the page has been reloaded.

## Verification

Measured against the production build via `vite preview`.

| Step | Input | Placeholder | Eye | Save | Delete | Raw token in DOM | Storage |
|---|---|---|---|---|---|---|---|
| Initial | empty | default | disabled | disabled | hidden | no | – |
| After typing | value | default | enabled | enabled | hidden | **yes** | – |
| **After save** | **empty** | **設定済み** | disabled | disabled | shown | **no** | stored |
| After reload | empty | 設定済み | disabled | disabled | shown | no | retained |

The last two rows are identical, which is the consistency this change was after. Saving still works end to end: the value reaches `sessionStorage` and the success alert appears. The visibility toggle was confirmed to switch `type` between `password` and `text` while the field has content.

`tsc`, `eslint`, `prettier --check` and `npm test` (16 files, 168 tests) all pass.

## Scope

This shortens how long the raw value sits in the DOM. **It is not an XSS defence**, and it does not change the conclusion from #79.

The token still lives in `sessionStorage` and in React state. With the field empty and the token absent from the DOM, it was still recovered from React state by walking the fiber tree from any DOM node:

```
inputValueInDOM:        ""
tokenFoundInDOM:        false
tokenFoundInReactState: [ 3 components, minified names, value intact ]
```

Patching `globalThis.fetch` to read the `Authorization` header works regardless of where the token is kept, since the value is assembled in plain text at request time.

What this does address is visual exposure — screen sharing, screenshots, shoulder surfing — and the window during which the DOM path is available at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)