### PR TITLE
feat(security): hold the API token in memory only

### DIFF
--- a/src/hooks/use-token.ts
+++ b/src/hooks/use-token.ts
@@ -1,9 +1,6 @@
-import { TOKEN_KEYS, TokenManager } from 'promidas-utils/token';
 import { useCallback, useEffect, useState } from 'react';
 
-const tokenStorage = TokenManager.forSessionStorage(
-  TOKEN_KEYS.PROTOPEDIA_API_V2_TOKEN,
-);
+import { inMemoryTokenStorage as tokenStorage } from '../lib/token/in-memory-token-storage';
 
 export { tokenStorage };
 

--- a/src/lib/repository/__tests__/protopedia-repository.test.ts
+++ b/src/lib/repository/__tests__/protopedia-repository.test.ts
@@ -25,18 +25,13 @@ const mocks = vi.hoisted(() => {
   };
 });
 
-vi.mock('promidas-utils/token', () => {
+vi.mock('../../token/in-memory-token-storage', () => {
   return {
-    TokenManager: {
-      forSessionStorage: () => ({
-        get: mocks.tokenStorageGet,
-        save: vi.fn(),
-        remove: vi.fn(),
-        has: vi.fn(),
-      }),
-    },
-    TOKEN_KEYS: {
-      PROTOPEDIA_API_V2_TOKEN: 'protopedia_api_v2_token',
+    inMemoryTokenStorage: {
+      get: mocks.tokenStorageGet,
+      save: vi.fn(),
+      remove: vi.fn(),
+      has: vi.fn(),
     },
   };
 });

--- a/src/lib/repository/protopedia-repository.ts
+++ b/src/lib/repository/protopedia-repository.ts
@@ -9,10 +9,10 @@ import {
   type ProtopediaInMemoryRepository,
   PromidasRepositoryBuilder,
 } from 'promidas';
-import { TOKEN_KEYS, TokenManager } from 'promidas-utils/token';
 
 import { resolveRepositoryInitFailure } from './init-error';
 import { createRepositoryConfigs } from './repository-config';
+import { inMemoryTokenStorage } from '../token/in-memory-token-storage';
 
 import type { LogLevel } from 'promidas/logger';
 
@@ -30,10 +30,9 @@ let repository: ProtopediaInMemoryRepository | null = null;
  */
 export async function getProtopediaRepository(): Promise<ProtopediaInMemoryRepository> {
   if (!repository) {
-    const tokenStorage = TokenManager.forSessionStorage(
-      TOKEN_KEYS.PROTOPEDIA_API_V2_TOKEN,
-    );
-    const token: string | null = await tokenStorage.get();
+    // Shared instance on purpose. The token lives only in memory now, so there
+    // is no backing store to synchronise a second instance through.
+    const token: string | null = await inMemoryTokenStorage.get();
 
     // For demo site, set log level to debug to help with troubleshooting
     const LOG_LEVEL_FOR_DEMO_SITE: LogLevel = 'debug';

--- a/src/lib/token/in-memory-token-storage.ts
+++ b/src/lib/token/in-memory-token-storage.ts
@@ -1,0 +1,42 @@
+/**
+ * @file In-memory storage for the ProtoPedia API token.
+ *
+ * The demo deliberately keeps the token out of Web Storage. `sessionStorage`
+ * would survive a reload, but it is also written to the browser profile for
+ * session restore, is readable by extension content scripts, and — because
+ * GitHub Pages puts every project of an account on one origin — stays readable
+ * after navigating the same tab to an unrelated page under that origin. Holding
+ * the token in a module variable closes those paths; the cost is that a reload
+ * discards it and the user has to enter it again.
+ *
+ * This is not a defence against XSS. Injected code can still reach the value
+ * through React's fiber tree or by patching `globalThis.fetch` to read the
+ * `Authorization` header, since the token is assembled in plain text whenever a
+ * request goes out.
+ *
+ * `promidas-utils` ships session, local and environment backends but no
+ * in-memory one, so this implements the exported `TokenStorage` interface
+ * directly. The type annotation keeps it honest if that interface changes.
+ */
+
+import type { TokenStorage } from 'promidas-utils/token';
+
+let token: string | null = null;
+
+/**
+ * Process-lifetime token storage shared across the app.
+ *
+ * Import this instance rather than constructing another one: React and the
+ * repository singleton both need to observe the same value, and there is no
+ * backing store to synchronise separate instances through.
+ */
+export const inMemoryTokenStorage: TokenStorage = {
+  has: async () => token !== null,
+  get: async () => token,
+  save: async (newToken: string) => {
+    token = newToken;
+  },
+  remove: async () => {
+    token = null;
+  },
+};


### PR DESCRIPTION
## Summary

Stop keeping the ProtoPedia API token in `sessionStorage`. It now lives in a module variable for the lifetime of the page.

Third change in this series, after #79 (CSP) and #80 (write-only token field).

## Why

`sessionStorage` survives a reload, which is convenient, but it also:

- gets written to the browser profile for session restore, so the token lands on disk;
- is readable by extension content scripts, which share the page's Web Storage but not its JavaScript scope;
- stays readable after navigating the same tab to another page on the origin. On GitHub Pages that origin covers every project under the account, and a stale Service Worker from an unrelated project already turned up on a shared port during this work.

A module variable closes all three.

## Changes

- **`src/lib/token/in-memory-token-storage.ts`** (new) — implements the `TokenStorage` interface exported by `promidas-utils`, backed by a single module-level variable. The library ships session, local and environment backends but no in-memory one; the type annotation is kept so interface drift surfaces at compile time.
- **`src/hooks/use-token.ts`** — imports the shared instance instead of calling `TokenManager.forSessionStorage()`.
- **`src/lib/repository/protopedia-repository.ts`** — same. This one matters: the hook and the repository singleton each constructed their own storage instance before and relied on `sessionStorage` to synchronise them. With no backing store, a second instance would silently observe no token.
- **Test** — the mock now targets the local module rather than `promidas-utils/token`.

## Verification

Measured against the production build via `vite preview`.

| Step | Input | Placeholder | `sessionStorage` keys | Delete button |
|---|---|---|---|---|
| Initial | empty | default | `[]` | hidden |
| **After save** | empty | 設定済み | **`[]`** | shown |
| **After reload** | empty | default | `[]` | hidden |

Saving writes nothing to `sessionStorage` or `localStorage`, and a reload discards the token. The unconfigured state renders normally with no error alerts — `init-error.ts` already classifies it as `MISSING_TOKEN`.

`tsc`, `eslint`, `prettier --check` and `npm test` (16 files, 168 tests) all pass.

## Cost

A reload discards the token and the user has to enter it again. That is the whole trade-off.

## Scope

**This is not an XSS defence**, and it does not change the conclusion from #79.

With the token held only in memory and absent from the DOM, injected code can still recover it by walking React's fiber tree from any DOM node — demonstrated during review, with the value intact across three components in a minified production build. Patching `globalThis.fetch` to read the `Authorization` header works regardless of where the token is kept, since it is assembled in plain text at request time.

What this addresses is the set of paths that do not require code execution in the page: disk persistence, extension content scripts, and same-tab navigation within the shared origin.

## Deliberately not included

- **Purging tokens left in `sessionStorage` by the previous build.** Only affects a tab that was already open with a saved token when the new build shipped, and closing the tab clears it. Adding the cleanup would reintroduce a `sessionStorage` reference into a codebase that no longer has one.
- **Adding `TokenManager.forMemory()` to `promidas-utils`.** Reasonable upstream, but out of scope here. Note for whenever it happens: it must share one module-level store across instances, mirroring how the existing backends share the browser's storage. Returning an isolated instance per call is exactly the failure mode this PR had to design around.

🤖 Generated with [Claude Code](https://claude.com/claude-code)