### PR TITLE
chore(release): 2026.08.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ and this project adheres to [CalVer](https://calver.org/).
 
 ## [Unreleased]
 
+## 2026-08-24
+
+### Added
+
+- Content Security Policy. Production builds carry it in a `<meta http-equiv>`
+  tag, because GitHub Pages cannot set response headers; the dev server serves
+  an equivalent policy as a real header. Every origin other than the ProtoPedia
+  API is denied, so `fetch`, `sendBeacon`, image and WebSocket requests can no
+  longer carry data off-site. Top-level navigation is not covered by any CSP
+  directive and remains possible.
+
+### Changed
+
+- The API token is no longer kept in `sessionStorage`. It lives in memory for
+  the lifetime of the page, so **a reload discards it and it has to be entered
+  again**. In exchange it never reaches disk, is out of reach of extension
+  content scripts, and stops being readable after navigating the tab to another
+  page on the shared `f88.github.io` origin.
+- The token field is now write-only. A stored token is no longer restored into
+  the input, and the field is cleared once the token is saved; the placeholder
+  reports that a token is set instead of showing it. The visibility toggle is
+  disabled while the field is empty, and still works while entering a value.
+
+### Fixed
+
+- Favicon. `index.html` pointed at `/vite.svg`, which existed nowhere in the
+  project and returned 404 on GitHub Pages.
+
 ## 2026-07-22
 
 ### PROMIDAS versions

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "promidas-demo",
-  "version": "2026.07.22",
+  "version": "2026.08.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "promidas-demo",
-      "version": "2026.07.22",
+      "version": "2026.08.24",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "promidas-demo",
   "private": true,
-  "version": "2026.07.22",
+  "version": "2026.08.24",
   "type": "module",
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
## Summary

Release 2026.08.24. Bumps `package.json` / `package-lock.json` and finalizes the `[Unreleased]` section of the CHANGELOG.

Covers #79, #80 and #81 — a set of changes to how the demo handles the ProtoPedia API token.

## CHANGELOG

### Added

- Content Security Policy. Production builds carry it in a `<meta http-equiv>` tag, because GitHub Pages cannot set response headers; the dev server serves an equivalent policy as a real header. Every origin other than the ProtoPedia API is denied, so `fetch`, `sendBeacon`, image and WebSocket requests can no longer carry data off-site. Top-level navigation is not covered by any CSP directive and remains possible.

### Changed

- The API token is no longer kept in `sessionStorage`. It lives in memory for the lifetime of the page, so **a reload discards it and it has to be entered again**. In exchange it never reaches disk, is out of reach of extension content scripts, and stops being readable after navigating the tab to another page on the shared `f88.github.io` origin.
- The token field is now write-only. A stored token is no longer restored into the input, and the field is cleared once the token is saved; the placeholder reports that a token is set instead of showing it. The visibility toggle is disabled while the field is empty, and still works while entering a value.

### Fixed

- Favicon. `index.html` pointed at `/vite.svg`, which existed nowhere in the project and returned 404 on GitHub Pages.

## Not in the CHANGELOG

`chore(lint): exclude storybook-static from eslint` is a tooling change with no user-visible effect, so it stays out per the project's CHANGELOG conventions. No promidas-family package versions changed in this release, so there is no `### PROMIDAS versions` section.

## Note for users

The token behaviour change is the one worth flagging. Entering a token and reloading now clears it — that is intended, not a regression.

## After merge

1. Tag the merge commit: `git tag 2026.08.24 && git push origin 2026.08.24`
2. `gh release create 2026.08.24` with this CHANGELOG section and a compare link against 2026.07.22

🤖 Generated with [Claude Code](https://claude.com/claude-code)