### PR TITLE
ci: verify formatting instead of auto-fixing it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,11 @@ jobs:
         # run: npm --loglevel debug list
         # run: npm --loglevel silly list
 
-      # - name: Run format check
-      #   run: npm run format:check
-      - name: Run format check and auto-fix
-        run: npm run format
+      # Verify formatting rather than auto-fixing it: `npm run format`
+      # rewrites files and exits 0, so unformatted code passed CI and the
+      # corrected files were discarded with the runner.
+      - name: Run format check
+        run: npm run format:check
 
       - name: Run lint
         run: npm run lint


### PR DESCRIPTION
## Summary

CI never verified formatting. This makes it do so.

## What was happening

The format step ran `npm run format`, which is `prettier --write`:

```yaml
      # - name: Run format check
      #   run: npm run format:check
      - name: Run format check and auto-fix
        run: npm run format
```

`--write` is not a verification command. It rewrites offending files and exits 0. So every CI run did this:

1. Check out the repository
2. Find the unformatted files
3. Format all of them
4. Exit 0 and move on
5. End the job — **the corrected files vanish with the runner**

Nothing was committed, nothing was pushed. The next run repeated the same work on the same files. The step name saying "format check" made it read as though something was being validated.

## Verification

`npm run format:check` already passes on `main` here — zero unformatted files — so this does not fail on existing code and needs no accompanying reformatting commit.

Behaviour against a deliberate violation:

| Command | Behaviour | Exit code |
|---|---|---|
| `npm run format:check` (new) | reports the offending file | **1 — CI fails** |
| `npm run format` (old) | silently rewrites it | **0 — CI passes** |

## Note

The replacement carries a comment explaining why, so the reasoning survives if someone considers switching back. If auto-fixing is preferred over failing, that needs a step which actually commits the result — otherwise it is equivalent to doing nothing.

Found while fixing the same issue in `pp-karuta` (F88/pp-karuta#60), where eight months of a check that could not fail had let 21 files drift out of compliance. This repository had not drifted, so the switch is free here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
